### PR TITLE
If provided, affect type in field documentation

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -152,7 +152,7 @@ class Service extends BaseService
         $requiredProperties = $properties = array();
         foreach ($service->fields as $field) {
             $properties[$field->getName()] = array(
-                'type' => 'string',
+                'type' => method_exists($field, 'getType') ? $field->getType() : 'string',
                 'description' => $field->getDescription()
             );
             if ($field->isRequired()) {


### PR DESCRIPTION
Allowes this module to pick up model datatypes, if provided by the Field object from zf-apigility-documentation (I'll submit a pull request after this). Defaults to string, like it was.