### PR TITLE
Call to a member function getName() on a non-object in zfcampus/zf-apigility-documentation-swagger/src/Service.php

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -122,7 +122,6 @@ class Service extends BaseService
                 'path' => $routeWithReplacements
             );
         } else {
-
             // find all other operations
             $operations = array();
             foreach ($service->operations as $operation) {
@@ -149,8 +148,14 @@ class Service extends BaseService
             );
         }
 
+        // Fields are part of the default input filter when present.
+        $fields = $service->fields;
+        if (isset($fields['input_filter'])) {
+            $fields = $fields['input_filter'];
+        }
+
         $requiredProperties = $properties = array();
-        foreach ($service->fields as $field) {
+        foreach ($fields as $field) {
             $properties[$field->getName()] = array(
                 'type' => method_exists($field, 'getType') ? $field->getType() : 'string',
                 'description' => $field->getDescription()


### PR DESCRIPTION
If an REST service contains at least one ore more fields, the following error occurs: 

Fatal error:  Call to a member function getName() on a non-object in /vendor/zfcampus/zf-apigility-documentation-swagger/src/Service.php on line 158

The reason is in case of  foreach ($service->fields as $field)  the $field contains an array of objects instead of the object itself.

Instead of using the following code:
```       
foreach ($service->fields as $field) {
    $properties[$field->getName()] = array(
        'type' => method_exists($field, 'getType') ? $field->getType() : 'string',
        'description' => $field->getDescription()
    );
    if ($field->isRequired()) {
        $requiredProperties[] = $field->getName();
    }
}
```       

the following code fixed my problem temporary:
```       
foreach ($service->fields as $field) {
    $field = $field[0]; // get object from first index of array
    $properties[$field->getName()] = array(
        'type' => method_exists($field, 'getType') ? $field->getType() : 'string',
        'description' => $field->getDescription()
    );
    if ($field->isRequired()) {
        $requiredProperties[] = $field->getName();
    }
}
```       
