### PR TITLE
delete default description for api

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -33,7 +33,7 @@ class Api extends BaseApi
             $services[] = [
                 'description' => ($description = $service->getDescription())
                 ? $description
-                : 'Operations for ' . $service->getName(),
+                : '',
                 'path' => '/' . $service->getName()
             ];
         }


### PR DESCRIPTION
No need for the text 'Operation for {Api}'