### PR TITLE
Fix SwaggerUiControllerFactory

### DIFF
--- a/src/SwaggerUiControllerFactory.php
+++ b/src/SwaggerUiControllerFactory.php
@@ -33,7 +33,7 @@ class SwaggerUiControllerFactory implements FactoryInterface
             ));
         }
 
-        return new SwaggerUiController($services->get(ApiFactory::class));
+        return new SwaggerUiController($container->get(ApiFactory::class));
     }
 
     /**

--- a/test/SwaggerUiControllerFactoryTest.php
+++ b/test/SwaggerUiControllerFactoryTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\Apigility\Documentation\Swagger;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\ModuleManager\ModuleManager;
+use Zend\ServiceManager\ServiceManager;
+use Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
+use ZF\Apigility\Documentation\ApiFactory;
+use ZF\Apigility\Documentation\Swagger\SwaggerUiControllerFactory;
+use ZF\Apigility\Provider\ApigilityProviderInterface;
+use ZF\Configuration\ModuleUtils;
+
+class SwaggerUiControllerFactoryTest extends TestCase
+{
+    /**
+     * @var SwaggerUiControllerFactory
+     */
+    protected $factory;
+
+    /**
+     * @var ServiceManager
+     */
+    protected $services;
+
+
+    protected function setUp()
+    {
+        $this->factory = new SwaggerUiControllerFactory();
+        $this->services = $services = new ServiceManager();
+
+        parent::setUp();
+    }
+
+    /**
+     * @expectedException \Zend\ServiceManager\Exception\ServiceNotCreatedException
+     */
+    public function testExceptionThrownOnMissingApiCreatorClass()
+    {
+        $smFactory = $this->factory;
+        $factory = $smFactory($this->services, 'SwaggerUiControllerFactory');
+        $this->assertInstanceOf('ZF\Apigility\Documentation\Swagger\SwaggerUiControllerFactory', $factory);
+
+        $factory();
+    }
+
+    public function testCreatesServiceWithDefaults()
+    {
+        $mockModule = $this->prophesize(ApigilityProviderInterface::class)->reveal();
+
+        $moduleManager = $this->prophesize(ModuleManager::class);
+        $moduleManager->getModules()->willReturn(['Test']);
+        $moduleManager->getModule('Test')->willReturn($mockModule);
+        $moduleUtils = $this->prophesize(ModuleUtils::class);
+        $moduleUtils
+            ->getModuleConfigPath('Test')
+            ->willReturn([]);
+
+        $apiFactory = new ApiFactory(
+            $moduleManager->reveal(),
+            [],
+            $moduleUtils->reveal()
+        );
+
+        $this->services->setService(ApiFactory::class, $apiFactory);
+
+        /** @var SwaggerUiControllerFactory $service */
+        $smFactory = $this->factory;
+        $this->assertInstanceOf('ZF\Apigility\Documentation\Swagger\SwaggerUiControllerFactory', $smFactory);
+
+        $controller = $smFactory($this->services, 'SwaggerUiControllerFactory');
+        $this->assertInstanceOf('ZF\Apigility\Documentation\Swagger\SwaggerUiController', $controller);
+    }
+}


### PR DESCRIPTION
This PR fixes a problem reported in issue #25 where the factor stopped instantiating the controller due to a wrong variable name. I've also added a unit test to detect problems with the factory.