### PR TITLE
skip Swagger model properties on invalid input_filter fields

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -6,6 +6,7 @@
 
 namespace ZF\Apigility\Documentation\Swagger;
 
+use ZF\Apigility\Documentation\Field;
 use ZF\Apigility\Documentation\Service as BaseService;
 
 class Service extends BaseService
@@ -156,6 +157,9 @@ class Service extends BaseService
 
         $requiredProperties = $properties = [];
         foreach ($fields as $field) {
+            if (!$field instanceof Field) {
+                continue;
+            }
             $properties[$field->getName()] = [
                 'type' => method_exists($field, 'getFieldType') ? $field->getFieldType() : 'string',
                 'dataType' => method_exists($field, 'getFieldType') ? $field->getFieldType() : 'string',


### PR DESCRIPTION
skip Swagger model properties when input_filter fields are incorrectly defined.

i have some routes defined that take advantage of the http-method-based input-filter-specs offered by zfcampus/zf-content-validation, namely an input-filter-spec for GET requests. this Swagger doc module isn't built to handle method-based models though, so i'm getting the following Fatal error in my error log:
```
[22-Feb-2017 19:47:17 UTC] PHP Fatal error:  Call to a member function getName() on array in /vagrant/vendor/zfcampus/zf-apigility-documentation-swagger/src/Service.php on line 159
[22-Feb-2017 19:47:17 UTC] PHP Stack trace:
[22-Feb-2017 19:47:17 UTC] PHP   1. {main}() /vagrant/public/index.php:0
[22-Feb-2017 19:47:17 UTC] PHP   2. Zend\Mvc\Application->run() /vagrant/public/index.php:51
[22-Feb-2017 19:47:17 UTC] PHP   3. Zend\Mvc\Application->completeRequest($event = *uninitialized*) /vagrant/vendor/zendframework/zend-mvc/src/Application.php:356
[22-Feb-2017 19:47:17 UTC] PHP   4. Zend\EventManager\EventManager->triggerEvent($event = *uninitialized*) /vagrant/vendor/zendframework/zend-mvc/src/Application.php:384
[22-Feb-2017 19:47:17 UTC] PHP   5. Zend\EventManager\EventManager->triggerListeners($event = *uninitialized*, $e = *uninitialized*, $callback = *uninitialized*) /vagrant/vendor/zendframework/zend-eventmanager/src/EventManager.php:251
[22-Feb-2017 19:47:17 UTC] PHP   6. call_user_func:{/vagrant/vendor/zendframework/zend-eventmanager/src/EventManager.php:490}(*uninitialized*, *uninitialized*) /vagrant/vendor/zendframework/zend-eventmanager/src/EventManager.php:490
[22-Feb-2017 19:47:17 UTC] PHP   7. Zend\Mvc\View\Http\DefaultRenderingStrategy->render($e = *uninitialized*) /vagrant/vendor/zendframework/zend-eventmanager/src/EventManager.php:490
[22-Feb-2017 19:47:17 UTC] PHP   8. Zend\View\View->render($model = *uninitialized*) /vagrant/vendor/zendframework/zend-mvc/src/View/Http/DefaultRenderingStrategy.php:105
[22-Feb-2017 19:47:17 UTC] PHP   9. Zend\View\Renderer\JsonRenderer->render($nameOrModel = *uninitialized*, $values = *uninitialized*) /vagrant/vendor/zendframework/zend-view/src/View.php:207
[22-Feb-2017 19:47:17 UTC] PHP  10. ZF\ContentNegotiation\JsonModel->serialize() /vagrant/vendor/zendframework/zend-view/src/Renderer/JsonRenderer.php:135
[22-Feb-2017 19:47:17 UTC] PHP  11. ZF\Apigility\Documentation\Swagger\ViewModel->getVariables() /vagrant/vendor/zfcampus/zf-content-negotiation/src/JsonModel.php:73
[22-Feb-2017 19:47:17 UTC] PHP  12. ZF\Apigility\Documentation\Swagger\Service->toArray() /vagrant/vendor/zfcampus/zf-apigility-documentation-swagger/src/ViewModel.php:32
```

this patch will fix the 500 error and restore my Swagger docs, but it doesn't solve the bigger question. if i choose to define different input-filter-specs for GET, POST, PUT, and PATCH, which one(s) should be used to define my Swagger model? i think GET shouldn't be considered because these are validator definitions for how my collection can be queried, and PATCH shouldn't be used since it's a partial model definition. we could check for POST and PUT input-filter-specs (in that order?) before falling back to the default.

this pull request acts as a safety net and will restore Swagger docs if anyone is using method-based input-filter-specs in their content-validation config.